### PR TITLE
Fix subfolder navigation

### DIFF
--- a/app.js
+++ b/app.js
@@ -94,7 +94,7 @@ function authenticationMiddleware () {
 app.get('*', authenticationMiddleware(), function (req, res, next) {
   var prefix = url.parse(req.originalUrl).pathname.split('/').slice(1).join('/');
   if (!prefix || prefix.endsWith('/')) {
-    s3bucket.listObjects({ Delimiter: `/${prefix}`, Prefix: prefix }, function (err, data) {
+    s3bucket.listObjects({ Delimiter: `/`, Prefix: prefix }, function (err, data) {
       if (err) { return next(err); }
       const hasIndex = !!data.Contents.find(c => c.Key === `${prefix}index.html`);
       if (hasIndex) {


### PR DESCRIPTION
Don't include the prefix in the delimiter, otherwise only the "folders"
at the bucket root are listed apart, while subfolders of subfolders
are all conflated in a single list.

Previously, in a bucket with a structure like

 - `folder1`
    - `subfolder11`
      - `file111`
      - `file112`
    - `subfolder12`
      - `file121`
      - `file122`
 - `folder2`
    - `subfolder21`
      - `file211`
      - `file212`

Then, the root level listing would show correctly:

    folder1/
    folder2/

But clicking on `folder1/` for instance would show:

    subfolder11/file111
    subfolder11/file112
    subfolder12/file121
    subfolder12/file122

Instead of the expected:

    subfolder11/
    subfolder12/
